### PR TITLE
Edit for grammar

### DIFF
--- a/ATTRIBUTIONS.md
+++ b/ATTRIBUTIONS.md
@@ -1,7 +1,7 @@
 wasm2native Attributions
-======================================
+========================
 
-wasm2native project reuses some components from other open source project:
+The `wasm2native` project reuses some components from other open source project:
 - **llvm**: for the AOT compilation
 - **wasm-micro-runtime**: for the AOT compilation and the auxiliary library
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@
 </div>
 
 ### Overview
-wasm2native allows developer to compile the WebAssembly file into a native object file, and then link it with an auxiliary library into a native binary, e.g., executable file, shared library or static library. It removes the wasm runtime dependency and provides two modes:
-- sandbox mode: the wasm sandbox is kept, and the wasm address space and native address space are different
-- [no-sandbox mode](https://github.com/AndroidWasm/wabt/tree/main/wasm2c#no-sandbox-mode-experimental), the wasm sandbox is discarded but it allows sharing pointers (both memory pointers and function pointers) between wasm and native, and the address space is the same in wasm and native.
+wasm2native allows developer to compile the WebAssembly file into a native object file, and then
+link it with an auxiliary library into a native binary, e.g., an executable file, shared library or
+static library. It removes the Wasm runtime dependency and provides two modes:
+- sandbox mode: the Wasm sandbox is kept, and the Wasm address space and native address space are
+  kept separate
+- [no-sandbox
+  mode](https://github.com/AndroidWasm/wabt/tree/main/wasm2c#no-sandbox-mode-experimental), the Wasm
+  sandbox is discarded; this means it allows sharing pointers (e.g., memory pointers, function
+  pointers) between Wasm and native and the address space is the same in Wasm and native.
 
 <img src="./doc/images/compilation_pipeline.svg" width="1100" height="220" />
 
@@ -23,6 +29,6 @@ wasm2native allows developer to compile the WebAssembly file into a native objec
 
 License
 =======
-wasm2native uses the same license as LLVM: the `Apache 2.0 license` with the LLVM exception. See the LICENSE file for details.
-This license allows you to freely use, modify, distribute and sell your own products based on wasm2native.
-Any contributions you make will be under the same license.
+wasm2native uses the same license as LLVM: the `Apache 2.0 license` with the LLVM exception. See the
+LICENSE file for details. This license allows you to freely use, modify, distribute and sell your
+own products based on wasm2native. Any contributions you make will be under the same license.

--- a/doc/build_wasm_app.md
+++ b/doc/build_wasm_app.md
@@ -1,8 +1,15 @@
 ### Pre-requisites
 
-Refer to [wasm_ndk of AnroidWasm](https://github.com/AndroidWasm/wasm_ndk?tab=readme-ov-file#pre-requisites) to install the toolchains. Note that when building the [Android Clang/LLVM Toolchain](https://android.googlesource.com/toolchain/llvm_android/+/master/README.md#android-clang_llvm-toolchain), apply the table64 patch to `llvm-toolchain/toolchain/llvm-project`: [[WebAssembly] Use 64-bit table when targeting wasm64](https://github.com/llvm/llvm-project/pull/92042) before the step `python toolchain/llvm_android/build.py`.
+Refer to [wasm_ndk of AndroidWasm] to install the toolchains. Note that when building the [Android
+Clang/LLVM Toolchain], apply the table64 patch to `llvm-toolchain/toolchain/llvm-project` ([#92042]) before the step `python
+toolchain/llvm_android/build.py`.
 
-Finally ensure that the below environment variables are set:
+[wasm_ndk of AndroidWasm]: https://github.com/AndroidWasm/wasm_ndk?tab=readme-ov-file#pre-requisites
+[Android Clang/LLVM Toolchain]: https://android.googlesource.com/toolchain/llvm_android/+/master/README.md#android-clang_llvm-toolchain
+[#92042]: https://github.com/llvm/llvm-project/pull/92042
+
+Then, ensure that the following environment variables are set:
+
 ```bash
 export ANDROID_NDK_HOME=<path/to/android-ndk-r26d>
 export ANDROID_CLANG_TOOLCHAIN=<path/to/linux-x86/clang-dev>
@@ -10,7 +17,7 @@ export WABT_HOME=<path/to/wabt>
 export WASM_NDK_ROOT=<path/to/wasm_ndk>
 ```
 
-And install [wasi-sdk](https://github.com/WebAssembly/wasi-sdk/tags).
+Install [wasi-sdk](https://github.com/WebAssembly/wasi-sdk/tags).
 
 ### Compile C/C++ source code to wasm32 sandbox mode
 

--- a/wasm2native-compiler/README.md
+++ b/wasm2native-compiler/README.md
@@ -1,14 +1,20 @@
-### Build wasm2native compiler
+### Compiler
 
-The wasm2native compiler is to compile wasm binary file to object file. You can execute following commands to build **wasm2native** compiler:
+The `wasm2native` compiler exists to compile Wasm modules to a native object file.
 
-For **Linux**(Ubuntu 20.04 as an example):
+### Build
 
-First, make sure necessary dependency are installed:
+To build the `wasm2native` compiler:
+
+##### Linux (e.g., Ubuntu 20.04)
+
+Install necessary dependencies:
 
 ```shell
-sudo apt-get install git build-essential cmake g++-multilib libgcc-9-dev lib32gcc-9-dev ccache 
+sudo apt-get install git build-essential cmake g++-multilib libgcc-9-dev lib32gcc-9-dev ccache
 ```
+
+Then, build the compiler:
 
 ```shell
 cd wasm2native-compiler
@@ -19,7 +25,7 @@ make
 # wasm2native is generated under current directory
 ```
 
-For **Windows**：
+##### Windows
 
 ```shell
 cd wasm2native-compiler

--- a/wasm2native-vmlib/README.md
+++ b/wasm2native-vmlib/README.md
@@ -1,10 +1,11 @@
-### Overview of the auxiliary lib
+### Auxiliary libraries
 
-The auxiliary lib provides extra functionalities for native binary:
-- For sandbox mode, it provides native API wrappers, memory allocator for host managed heap, and APIs to execute the wasm functions in the native binary. The built out lib is libvmlib.a.
-- For no-sandbox mode, it only provides API wrappers. The built out lib is libnosandbox.a.
+These auxiliary libraries provide extra functionality for a `wasm2native` binary:
+- `libvmlib.a`: designed for sandbox mode, this library provides native API wrappers, a memory
+  allocator for a host-managed heap, and APIs to execute the Wasm functions in the native binary.
+- `libnosandbox.a`: for no-sandbox mode, this library only provides API wrappers.
 
-### Build the auxiliary lib
+### Build
 
 ```shell
 cd wasm2native-vmlib


### PR DESCRIPTION
This round of edits fixes in grammar in many of the `*.md` files. Another round is likely necessary once the documentation is filled out, since there are many pending `TODO`s.