### PR TITLE
Align to the latest code of WAMR and update llvm to latest version

### DIFF
--- a/build-scripts/build_llvm.py
+++ b/build-scripts/build_llvm.py
@@ -158,6 +158,8 @@ def build_llvm(llvm_dir, platform, backends, projects, use_clang=False, extra_fl
     BUILD_CMD = "cmake --build . --target package" + (
         " --config Release" if "windows" == platform else ""
     )
+    if "windows" == platform:
+        BUILD_CMD += " --parallel " + str(os.cpu_count())
     print(f"\nbuild command: {BUILD_CMD}\n")
     subprocess.check_call(shlex.split(BUILD_CMD), cwd=build_dir)
 
@@ -254,17 +256,17 @@ def main():
         "arc": {
             "repo": "https://github.com/llvm/llvm-project.git",
             "repo_ssh": "git@github.com:llvm/llvm-project.git",
-            "branch": "release/18.x",
+            "branch": "release/19.x",
         },
         "xtensa": {
             "repo": "https://github.com/espressif/llvm-project.git",
             "repo_ssh": "git@github.com:espressif/llvm-project.git",
-            "branch": "xtensa_release_18.x",
+            "branch": "xtensa_release_17.0.1",
         },
         "default": {
             "repo": "https://github.com/llvm/llvm-project.git",
             "repo_ssh": "git@github.com:llvm/llvm-project.git",
-            "branch": "release/18.x",
+            "branch": "release/19.x",
         },
     }
 

--- a/build-scripts/requirements.txt
+++ b/build-scripts/requirements.txt
@@ -1,1 +1,1 @@
-requests==2.31.0
+requests==2.32.3

--- a/core/iwasm/common/wasm.h
+++ b/core/iwasm/common/wasm.h
@@ -669,6 +669,25 @@ block_type_get_result_types(BlockType *block_type, uint8 **p_result_types)
     return result_count;
 }
 
+static inline uint32
+block_type_get_arity(const BlockType *block_type, uint8 label_type)
+{
+    if (label_type == LABEL_TYPE_LOOP) {
+        if (block_type->is_value_type)
+            return 0;
+        else
+            return block_type->u.type->param_count;
+    }
+    else {
+        if (block_type->is_value_type) {
+            return block_type->u.value_type != VALUE_TYPE_VOID ? 1 : 0;
+        }
+        else
+            return block_type->u.type->result_count;
+    }
+    return 0;
+}
+
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif

--- a/core/iwasm/common/wasm_opcode.h
+++ b/core/iwasm/common/wasm_opcode.h
@@ -477,7 +477,7 @@ typedef enum WASMSimdEXTOpcode {
     SIMD_i16x8_min_u = 0x97,
     SIMD_i16x8_max_s = 0x98,
     SIMD_i16x8_max_u = 0x99,
-    /* placeholder            = 0x9a */
+    /* placeholder = 0x9a */
     SIMD_i16x8_avgr_u = 0x9b,
     SIMD_i16x8_extmul_low_i8x16_s = 0x9c,
     SIMD_i16x8_extmul_high_i8x16_s = 0x9d,
@@ -487,11 +487,11 @@ typedef enum WASMSimdEXTOpcode {
     /* i32x4 operation */
     SIMD_i32x4_abs = 0xa0,
     SIMD_i32x4_neg = 0xa1,
-    /* placeholder            = 0xa2 */
+    /* placeholder = 0xa2 */
     SIMD_i32x4_all_true = 0xa3,
     SIMD_i32x4_bitmask = 0xa4,
-    SIMD_i32x4_narrow_i64x2_s = 0xa5,
-    SIMD_i32x4_narrow_i64x2_u = 0xa6,
+    /* placeholder = 0xa5 */
+    /* placeholder = 0xa6 */
     SIMD_i32x4_extend_low_i16x8_s = 0xa7,
     SIMD_i32x4_extend_high_i16x8_s = 0xa8,
     SIMD_i32x4_extend_low_i16x8_u = 0xa9,
@@ -500,19 +500,19 @@ typedef enum WASMSimdEXTOpcode {
     SIMD_i32x4_shr_s = 0xac,
     SIMD_i32x4_shr_u = 0xad,
     SIMD_i32x4_add = 0xae,
-    SIMD_i32x4_add_sat_s = 0xaf,
-    SIMD_i32x4_add_sat_u = 0xb0,
+    /* placeholder = 0xaf */
+    /* placeholder = 0xb0 */
     SIMD_i32x4_sub = 0xb1,
-    SIMD_i32x4_sub_sat_s = 0xb2,
-    SIMD_i32x4_sub_sat_u = 0xb3,
-    /* placeholder            = 0xb4 */
+    /* placeholder = 0xb2 */
+    /* placeholder = 0xb3 */
+    /* placeholder = 0xb4 */
     SIMD_i32x4_mul = 0xb5,
     SIMD_i32x4_min_s = 0xb6,
     SIMD_i32x4_min_u = 0xb7,
     SIMD_i32x4_max_s = 0xb8,
     SIMD_i32x4_max_u = 0xb9,
     SIMD_i32x4_dot_i16x8_s = 0xba,
-    SIMD_i32x4_avgr_u = 0xbb,
+    /* placeholder = 0xbb */
     SIMD_i32x4_extmul_low_i16x8_s = 0xbc,
     SIMD_i32x4_extmul_high_i16x8_s = 0xbd,
     SIMD_i32x4_extmul_low_i16x8_u = 0xbe,
@@ -521,11 +521,11 @@ typedef enum WASMSimdEXTOpcode {
     /* i64x2 operation */
     SIMD_i64x2_abs = 0xc0,
     SIMD_i64x2_neg = 0xc1,
-    /* placeholder       = 0xc2 */
+    /* placeholder = 0xc2 */
     SIMD_i64x2_all_true = 0xc3,
     SIMD_i64x2_bitmask = 0xc4,
-    /* placeholder       = 0xc5 */
-    /* placeholder       = 0xc6 */
+    /* placeholder = 0xc5 */
+    /* placeholder = 0xc6 */
     SIMD_i64x2_extend_low_i32x4_s = 0xc7,
     SIMD_i64x2_extend_high_i32x4_s = 0xc8,
     SIMD_i64x2_extend_low_i32x4_u = 0xc9,
@@ -534,12 +534,12 @@ typedef enum WASMSimdEXTOpcode {
     SIMD_i64x2_shr_s = 0xcc,
     SIMD_i64x2_shr_u = 0xcd,
     SIMD_i64x2_add = 0xce,
-    /* placeholder       = 0xcf */
-    /* placeholder       = 0xd0 */
+    /* placeholder = 0xcf */
+    /* placeholder = 0xd0 */
     SIMD_i64x2_sub = 0xd1,
-    /* placeholder       = 0xd2 */
-    /* placeholder       = 0xd3 */
-    /* placeholder       = 0xd4 */
+    /* placeholder = 0xd2 */
+    /* placeholder = 0xd3 */
+    /* placeholder = 0xd4 */
     SIMD_i64x2_mul = 0xd5,
     SIMD_i64x2_eq = 0xd6,
     SIMD_i64x2_ne = 0xd7,
@@ -555,7 +555,7 @@ typedef enum WASMSimdEXTOpcode {
     /* f32x4 operation */
     SIMD_f32x4_abs = 0xe0,
     SIMD_f32x4_neg = 0xe1,
-    SIMD_f32x4_round = 0xe2,
+    /* placeholder = 0xe2 */
     SIMD_f32x4_sqrt = 0xe3,
     SIMD_f32x4_add = 0xe4,
     SIMD_f32x4_sub = 0xe5,
@@ -569,7 +569,7 @@ typedef enum WASMSimdEXTOpcode {
     /* f64x2 operation */
     SIMD_f64x2_abs = 0xec,
     SIMD_f64x2_neg = 0xed,
-    SIMD_f64x2_round = 0xee,
+    /* placeholder = 0xee */
     SIMD_f64x2_sqrt = 0xef,
     SIMD_f64x2_add = 0xf0,
     SIMD_f64x2_sub = 0xf1,

--- a/core/iwasm/compilation/aot.h
+++ b/core/iwasm/compilation/aot.h
@@ -255,7 +255,7 @@ typedef struct AOTCompData {
 
 typedef struct AOTNativeSymbol {
     bh_list_link link;
-    char symbol[32];
+    char symbol[48];
     int32 index;
 } AOTNativeSymbol;
 

--- a/core/iwasm/compilation/aot_compiler.c
+++ b/core/iwasm/compilation/aot_compiler.c
@@ -239,7 +239,9 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                 }
                 else {
                     frame_ip--;
-                    read_leb_uint32(frame_ip, frame_ip_end, type_index);
+                    read_leb_int32(frame_ip, frame_ip_end, type_index);
+                    /* type index was checked in wasm loader */
+                    bh_assert(type_index < comp_ctx->comp_data->type_count);
                     func_type = comp_ctx->comp_data->func_types[type_index];
                     param_count = func_type->param_count;
                     param_types = func_type->types;
@@ -258,7 +260,9 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
             case EXT_OP_LOOP:
             case EXT_OP_IF:
             {
-                read_leb_uint32(frame_ip, frame_ip_end, type_index);
+                read_leb_int32(frame_ip, frame_ip_end, type_index);
+                /* type index was checked in wasm loader */
+                bh_assert(type_index < comp_ctx->comp_data->type_count);
                 func_type = comp_ctx->comp_data->func_types[type_index];
                 param_count = func_type->param_count;
                 param_types = func_type->types;
@@ -2112,16 +2116,6 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                         break;
                     }
 
-                    case SIMD_i32x4_narrow_i64x2_s:
-                    case SIMD_i32x4_narrow_i64x2_u:
-                    {
-                        if (!aot_compile_simd_i32x4_narrow_i64x2(
-                                comp_ctx, func_ctx,
-                                SIMD_i32x4_narrow_i64x2_s == opcode))
-                            return false;
-                        break;
-                    }
-
                     case SIMD_i32x4_extend_low_i16x8_s:
                     case SIMD_i32x4_extend_high_i16x8_s:
                     {
@@ -2161,30 +2155,10 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                         break;
                     }
 
-                    case SIMD_i32x4_add_sat_s:
-                    case SIMD_i32x4_add_sat_u:
-                    {
-                        if (!aot_compile_simd_i32x4_saturate(
-                                comp_ctx, func_ctx, V128_ADD,
-                                opcode == SIMD_i32x4_add_sat_s))
-                            return false;
-                        break;
-                    }
-
                     case SIMD_i32x4_sub:
                     {
                         if (!aot_compile_simd_i32x4_arith(comp_ctx, func_ctx,
                                                           V128_SUB))
-                            return false;
-                        break;
-                    }
-
-                    case SIMD_i32x4_sub_sat_s:
-                    case SIMD_i32x4_sub_sat_u:
-                    {
-                        if (!aot_compile_simd_i32x4_saturate(
-                                comp_ctx, func_ctx, V128_SUB,
-                                opcode == SIMD_i32x4_add_sat_s))
                             return false;
                         break;
                     }
@@ -2221,13 +2195,6 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                     {
                         if (!aot_compile_simd_i32x4_dot_i16x8(comp_ctx,
                                                               func_ctx))
-                            return false;
-                        break;
-                    }
-
-                    case SIMD_i32x4_avgr_u:
-                    {
-                        if (!aot_compile_simd_i32x4_avgr_u(comp_ctx, func_ctx))
                             return false;
                         break;
                     }
@@ -2388,13 +2355,6 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                         break;
                     }
 
-                    case SIMD_f32x4_round:
-                    {
-                        if (!aot_compile_simd_f32x4_round(comp_ctx, func_ctx))
-                            return false;
-                        break;
-                    }
-
                     case SIMD_f32x4_sqrt:
                     {
                         if (!aot_compile_simd_f32x4_sqrt(comp_ctx, func_ctx))
@@ -2444,13 +2404,6 @@ aot_compile_func(AOTCompContext *comp_ctx, uint32 func_index)
                     case SIMD_f64x2_neg:
                     {
                         if (!aot_compile_simd_f64x2_neg(comp_ctx, func_ctx))
-                            return false;
-                        break;
-                    }
-
-                    case SIMD_f64x2_round:
-                    {
-                        if (!aot_compile_simd_f64x2_round(comp_ctx, func_ctx))
                             return false;
                         break;
                     }

--- a/core/iwasm/compilation/aot_emit_control.c
+++ b/core/iwasm/compilation/aot_emit_control.c
@@ -929,6 +929,7 @@ aot_compile_op_br_table(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                         PUSH(values[j], target_block->result_types[j]);
                     }
                     wasm_runtime_free(values);
+                    values = NULL;
                 }
                 target_block->is_reachable = true;
                 if (i == br_count)
@@ -954,6 +955,7 @@ aot_compile_op_br_table(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                         PUSH(values[j], target_block->param_types[j]);
                     }
                     wasm_runtime_free(values);
+                    values = NULL;
                 }
                 if (i == br_count)
                     default_llvm_block = target_block->llvm_entry_block;

--- a/core/iwasm/compilation/simd/simd_access_lanes.c
+++ b/core/iwasm/compilation/simd/simd_access_lanes.c
@@ -84,7 +84,7 @@ aot_compile_simd_swizzle_x86(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 
     if (!(condition = LLVMBuildICmp(comp_ctx->builder, LLVMIntUGE, mask,
                                     max_lanes, "compare_with_16"))) {
-        HANDLE_FAILURE("LLVMBuldICmp");
+        HANDLE_FAILURE("LLVMBuildICmp");
         goto fail;
     }
 
@@ -362,7 +362,7 @@ aot_compile_simd_replace(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         goto fail;
     }
 
-    return simd_bitcast_and_push_v128(comp_ctx, func_ctx, result, "reesult");
+    return simd_bitcast_and_push_v128(comp_ctx, func_ctx, result, "result");
 
 fail:
     return false;

--- a/core/iwasm/compilation/simd/simd_comparisons.c
+++ b/core/iwasm/compilation/simd/simd_comparisons.c
@@ -85,7 +85,7 @@ fail:
 }
 
 static bool
-interger_vector_compare(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
+integer_vector_compare(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                         IntCond cond, LLVMTypeRef vector_type)
 {
     LLVMValueRef vec1, vec2, result;
@@ -137,28 +137,28 @@ bool
 aot_compile_simd_i8x16_compare(AOTCompContext *comp_ctx,
                                AOTFuncContext *func_ctx, IntCond cond)
 {
-    return interger_vector_compare(comp_ctx, func_ctx, cond, V128_i8x16_TYPE);
+    return integer_vector_compare(comp_ctx, func_ctx, cond, V128_i8x16_TYPE);
 }
 
 bool
 aot_compile_simd_i16x8_compare(AOTCompContext *comp_ctx,
                                AOTFuncContext *func_ctx, IntCond cond)
 {
-    return interger_vector_compare(comp_ctx, func_ctx, cond, V128_i16x8_TYPE);
+    return integer_vector_compare(comp_ctx, func_ctx, cond, V128_i16x8_TYPE);
 }
 
 bool
 aot_compile_simd_i32x4_compare(AOTCompContext *comp_ctx,
                                AOTFuncContext *func_ctx, IntCond cond)
 {
-    return interger_vector_compare(comp_ctx, func_ctx, cond, V128_i32x4_TYPE);
+    return integer_vector_compare(comp_ctx, func_ctx, cond, V128_i32x4_TYPE);
 }
 
 bool
 aot_compile_simd_i64x2_compare(AOTCompContext *comp_ctx,
                                AOTFuncContext *func_ctx, IntCond cond)
 {
-    return interger_vector_compare(comp_ctx, func_ctx, cond, V128_i64x2_TYPE);
+    return integer_vector_compare(comp_ctx, func_ctx, cond, V128_i64x2_TYPE);
 }
 
 static bool

--- a/core/iwasm/compilation/simd/simd_conversions.c
+++ b/core/iwasm/compilation/simd/simd_conversions.c
@@ -11,7 +11,7 @@
 static bool
 simd_integer_narrow_x86(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
                         LLVMTypeRef in_vector_type, LLVMTypeRef out_vector_type,
-                        const char *instrinsic)
+                        const char *intrinsic)
 {
     LLVMValueRef vector1, vector2, result;
     LLVMTypeRef param_types[2] = { in_vector_type, in_vector_type };
@@ -23,7 +23,7 @@ simd_integer_narrow_x86(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
 
-    if (!(result = aot_call_llvm_intrinsic(comp_ctx, func_ctx, instrinsic,
+    if (!(result = aot_call_llvm_intrinsic(comp_ctx, func_ctx, intrinsic,
                                            out_vector_type, param_types, 2,
                                            vector1, vector2))) {
         HANDLE_FAILURE("LLVMBuildCall");
@@ -225,15 +225,6 @@ aot_compile_simd_i16x8_narrow_i32x4(AOTCompContext *comp_ctx,
     }
 }
 
-bool
-aot_compile_simd_i32x4_narrow_i64x2(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx, bool is_signed)
-{
-    /* TODO: x86 intrinsics */
-    return simd_integer_narrow_common(comp_ctx, func_ctx, e_sat_i64x2,
-                                      is_signed);
-}
-
 enum integer_extend_type {
     e_ext_i8x16,
     e_ext_i16x8,
@@ -269,7 +260,7 @@ simd_integer_extension(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
         return false;
     }
 
-    /* retrive the low or high half */
+    /* retrieve the low or high half */
     if (!(sub_vector = LLVMBuildShuffleVector(comp_ctx->builder, vector,
                                               undef[itype], mask, "half"))) {
         HANDLE_FAILURE("LLVMBuildShuffleVector");
@@ -667,7 +658,7 @@ aot_compile_simd_i16x8_q15mulr_sat(AOTCompContext *comp_ctx,
 
     if (!(result = LLVMBuildTrunc(comp_ctx->builder, result, V128_i16x8_TYPE,
                                   "down_to_v8i16"))) {
-        HANDLE_FAILURE("LLVMBuidlTrunc");
+        HANDLE_FAILURE("LLVMBuildTrunc");
         return false;
     }
 

--- a/core/iwasm/compilation/simd/simd_conversions.h
+++ b/core/iwasm/compilation/simd/simd_conversions.h
@@ -21,10 +21,6 @@ aot_compile_simd_i16x8_narrow_i32x4(AOTCompContext *comp_ctx,
                                     AOTFuncContext *func_ctx, bool is_signed);
 
 bool
-aot_compile_simd_i32x4_narrow_i64x2(AOTCompContext *comp_ctx,
-                                    AOTFuncContext *func_ctx, bool is_signed);
-
-bool
 aot_compile_simd_i16x8_extend_i8x16(AOTCompContext *comp_ctx,
                                     AOTFuncContext *func_ctx, bool is_low,
                                     bool is_signed);

--- a/core/iwasm/compilation/simd/simd_floating_point.c
+++ b/core/iwasm/compilation/simd/simd_floating_point.c
@@ -129,20 +129,6 @@ aot_compile_simd_f64x2_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 }
 
 bool
-aot_compile_simd_f32x4_round(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
-{
-    return simd_float_intrinsic(comp_ctx, func_ctx, V128_f32x4_TYPE,
-                                "llvm.round.v4f32");
-}
-
-bool
-aot_compile_simd_f64x2_round(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
-{
-    return simd_float_intrinsic(comp_ctx, func_ctx, V128_f64x2_TYPE,
-                                "llvm.round.v2f64");
-}
-
-bool
 aot_compile_simd_f32x4_sqrt(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 {
     return simd_float_intrinsic(comp_ctx, func_ctx, V128_f32x4_TYPE,

--- a/core/iwasm/compilation/simd/simd_floating_point.h
+++ b/core/iwasm/compilation/simd/simd_floating_point.h
@@ -33,14 +33,6 @@ bool
 aot_compile_simd_f64x2_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 bool
-aot_compile_simd_f32x4_round(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx);
-
-bool
-aot_compile_simd_f64x2_round(AOTCompContext *comp_ctx,
-                             AOTFuncContext *func_ctx);
-
-bool
 aot_compile_simd_f32x4_sqrt(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx);
 
 bool

--- a/core/iwasm/compilation/simd/simd_int_arith.c
+++ b/core/iwasm/compilation/simd/simd_int_arith.c
@@ -242,7 +242,6 @@ aot_compile_simd_i64x2_abs(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx)
 enum integer_avgr_u {
     e_avgr_u_i8x16,
     e_avgr_u_i16x8,
-    e_avgr_u_i32x4,
 };
 
 /* TODO: try int_x86_mmx_pavg_b and int_x86_mmx_pavg_w */
@@ -256,9 +255,8 @@ simd_v128_avg(AOTCompContext *comp_ctx, AOTFuncContext *func_ctx,
     LLVMTypeRef vector_type[] = {
         V128_i8x16_TYPE,
         V128_i16x8_TYPE,
-        V128_i32x4_TYPE,
     };
-    unsigned lanes[] = { 16, 8, 4 };
+    unsigned lanes[] = { 16, 8 };
 
     if (!(rhs = simd_pop_v128_and_bitcast(comp_ctx, func_ctx,
                                           vector_type[itype], "rhs"))
@@ -322,13 +320,6 @@ aot_compile_simd_i16x8_avgr_u(AOTCompContext *comp_ctx,
                               AOTFuncContext *func_ctx)
 {
     return simd_v128_avg(comp_ctx, func_ctx, e_avgr_u_i16x8);
-}
-
-bool
-aot_compile_simd_i32x4_avgr_u(AOTCompContext *comp_ctx,
-                              AOTFuncContext *func_ctx)
-{
-    return simd_v128_avg(comp_ctx, func_ctx, e_avgr_u_i32x4);
 }
 
 bool

--- a/core/iwasm/compilation/simd/simd_int_arith.h
+++ b/core/iwasm/compilation/simd/simd_int_arith.h
@@ -77,10 +77,6 @@ aot_compile_simd_i16x8_avgr_u(AOTCompContext *comp_ctx,
                               AOTFuncContext *func_ctx);
 
 bool
-aot_compile_simd_i32x4_avgr_u(AOTCompContext *comp_ctx,
-                              AOTFuncContext *func_ctx);
-
-bool
 aot_compile_simd_i32x4_dot_i16x8(AOTCompContext *comp_ctx,
                                  AOTFuncContext *func_ctx);
 

--- a/core/iwasm/compilation/simd/simd_sat_int_arith.c
+++ b/core/iwasm/compilation/simd/simd_sat_int_arith.c
@@ -63,18 +63,3 @@ aot_compile_simd_i16x8_saturate(AOTCompContext *comp_ctx,
                               is_signed ? intrinsics[arith_op][0]
                                         : intrinsics[arith_op][1]);
 }
-
-bool
-aot_compile_simd_i32x4_saturate(AOTCompContext *comp_ctx,
-                                AOTFuncContext *func_ctx,
-                                V128Arithmetic arith_op, bool is_signed)
-{
-    char *intrinsics[][2] = {
-        { "llvm.sadd.sat.v4i32", "llvm.uadd.sat.v4i32" },
-        { "llvm.ssub.sat.v4i32", "llvm.usub.sat.v4i32" },
-    };
-
-    return simd_sat_int_arith(comp_ctx, func_ctx, V128_i16x8_TYPE,
-                              is_signed ? intrinsics[arith_op][0]
-                                        : intrinsics[arith_op][1]);
-}

--- a/core/iwasm/compilation/simd/simd_sat_int_arith.h
+++ b/core/iwasm/compilation/simd/simd_sat_int_arith.h
@@ -22,10 +22,6 @@ aot_compile_simd_i16x8_saturate(AOTCompContext *comp_ctx,
                                 AOTFuncContext *func_ctx,
                                 V128Arithmetic arith_op, bool is_signed);
 
-bool
-aot_compile_simd_i32x4_saturate(AOTCompContext *comp_ctx,
-                                AOTFuncContext *func_ctx,
-                                V128Arithmetic arith_op, bool is_signed);
 #ifdef __cplusplus
 } /* end of extern "C" */
 #endif


### PR DESCRIPTION
Align to the latest code of WAMR, apply the below patches of WAMR:
- Fix warnings/issues reported in Windows and by CodeQL/Coverity (#3275)
- Sync simd opcode definitions spec (#3290)
- Add more checks in wasm loader (#3300)
- wasm loader: Fix checks for opcode ref.func and opcode else (#3340)
- Enhance wasm loader checks for opcode br_table (#3352)
- Fix loader and mini-loader select potiential error (#3374)
- Fix some more spelling issues (#3393)
- wasm loader: Fix handling if block without op else (#3404)
- aot: Make precheck functions use short-call for xtensa (#3418)
- aot compiler: Fix a type mismatch in compile_op_float_min_max (#3423)
- Fix two issues to make fuzzing test quit earlier (#3471)
- Fix loader parse block type and calculate dynamic offset for loop args (#3482)
- Fix wasm loader check data segment count (#3492)
- build_llvm.py: Speed up llvm build with multi procs on windows (#3512)
- aot compiler: Propagate const-ness by ourselves (#3567)
- Add integer overflow check for some indices in wasm/aot loader (#3579)
- aot compiler: Enlarge AOTNativeSymbol->symbol (#3662)